### PR TITLE
View Open Data Sets Link 404 Fix

### DIFF
--- a/civic-hacking-101.jade
+++ b/civic-hacking-101.jade
@@ -57,7 +57,7 @@ section(class='row block')
 
     h2 How can you contribute?
     p The possibilities for contributing to Code for Miami are many, but here are some ways to get started:
-      li Come out to our weekly Civic Hack Night at the LAB, happening every Monday from 7 to 9pm, to contribute to one of our projects.
+      li Come out to our weekly Civic Hack Night at CIC Miami, happening every Monday from 7 to 9pm, to contribute to one of our projects.
       li Attend one of our upcoming events or workshops.
       li Partner with us to develop an event or sponsor a planned event.
       li Feed our civic hackers by donating food to our weekly meetings.

--- a/index.jade
+++ b/index.jade
@@ -28,6 +28,6 @@ section(class='row row-whatwedo')
         h3 Open Data Advocacy
         p Open data is data that can be freely used, reused and redistributed by anyone - subject only, at most, to the requirement to attribute and sharealike.
         div
-            a(href='https://github.com/Code-for-Miami/data-sets') <img src='images/icons/arrow-black.svg' class='icon-small'> View Open Data Sets
+            a(href='http://miamiopendata.org/') <img src='images/icons/arrow-black.svg' class='icon-small'> Learn about Open Data
         div
             a(href='http://miamiopendata.org#petition-form') <img src='images/icons/arrow-black.svg' class='icon-small'> Sign our petition


### PR DESCRIPTION
Github repo not found for link “view open data sets”. Changed to
miamiopendata.org homepage with text “Learn About Open Data”.
