### PR TITLE
Fix projects page in Firefox by removing User-Agent header

### DIFF
--- a/js/services/cfaApi.js
+++ b/js/services/cfaApi.js
@@ -7,16 +7,11 @@
 
         function getSearch(pageCount, pageNumber, type) {
             var currentPage = pageNumber || 1;
-            var url = apiUrl + type + '?per_page=' + pageCount + '&page=' + currentPage + '&q=user:' + brigadeName,
-                options = {
-                    headers: {
-                        'User-Agent': 'node.js'
-                    }
-                };
+            var url = apiUrl + type + '?per_page=' + pageCount + '&page=' + currentPage + '&q=user:' + brigadeName;
 
             if(type === 'issues') url = url + '+state:open';
 
-            return $http.get(url, options)
+            return $http.get(url)
                 .then(function (res) {
                     return res.data;
                 });


### PR DESCRIPTION
I'm getting an error on http://codefor.miami/projects in Firefox because Github doesn't permit the `User-Agent` header for CORS requests. (Chrome permits the request, but just does not set this header.) Removing the explicit `User-Agent` header option should get the job done to re-enable these requests.

(Hello! I'm looking into how a random sample of brigades display their projects on their website, and thought I'd send in a quick PR since I noticed this glitch.)